### PR TITLE
Add per-channel minimum video duration parameter

### DIFF
--- a/src/ChannelTube.py
+++ b/src/ChannelTube.py
@@ -126,6 +126,7 @@ class DataHandler:
                     "Media_Type": channel.get("Media_Type", "Video"),
                     "Search_Limit": channel.get("Search_Limit", ""),
                     "Live_Rule": channel.get("Live_Rule", "Ignore"),
+                    "Minimum_Duration_Minutes": channel.get("Minimum_Duration_Minutes"),
                 }
 
                 self.req_channel_list.append(full_channel_data)
@@ -167,6 +168,7 @@ class DataHandler:
         days_to_retrieve = channel["DL_Days"]
         channel_link = channel["Link"]
         search_limit = channel["Search_Limit"]
+        minimum_duration_minutes = channel["Minimum_Duration_Minutes"]*60
         video_to_download_list = []
 
         ydl_opts = {
@@ -236,7 +238,7 @@ class DataHandler:
                     self.general_logger.warning(f"Ignoring live video: {video_title} - {video_link}")
                     continue
 
-                if duration <= 180 and live_status is None:
+                if duration <= minimum_duration_minutes and live_status is None:
                     self.general_logger.warning(f"Ignoring short video: {video_title} - {video_link}")
                     continue
 
@@ -604,6 +606,7 @@ class DataHandler:
             "Media_Type": "Video",
             "Search_Limit": "",
             "Live_Rule": "Ignore",
+            "Minimum_Duration_Minutes": 3,
         }
         self.req_channel_list.append(new_channel)
         socketio.emit("new_channel_added", new_channel)

--- a/src/static/script.js
+++ b/src/static/script.js
@@ -38,6 +38,7 @@ function open_edit_modal(channel_id) {
     const filter_text_description = modal.querySelector("#filter-text-description");
     const search_limit_input = modal.querySelector("#search-limit");
     const live_rule_selector = modal.querySelectorAll("input[name='live-rule-selector']");
+    const duration_minim_limit_input = modal.querySelector("#minimum-duration-minutes");
 
     channel_name_input.value = channel.Name;
     channel_link_input.value = channel.Link;
@@ -46,6 +47,7 @@ function open_edit_modal(channel_id) {
     title_filter_text_input.value = channel.Filter_Title_Text;
     negate_filter_checkbox.checked = channel.Negate_Filter;
     search_limit_input.value = channel.Search_Limit;
+    duration_minim_limit_input.value = channel.Minimum_Duration_Minutes;
 
     change_filter_description(negate_filter_checkbox, filter_text_description);
 
@@ -135,7 +137,8 @@ function save_channel_changes(channel) {
         Negate_Filter: document.getElementById("negate-filter").checked,
         Media_Type: document.querySelector("input[name='media-type-selector']:checked").value,
         Search_Limit: document.getElementById("search-limit").value,
-        Live_Rule: document.querySelector("input[name='live-rule-selector']:checked").value
+        Live_Rule: document.querySelector("input[name='live-rule-selector']:checked").value,
+        Minimum_Duration_Minutes: parseInt(document.getElementById("minimum-duration-minutes").value, 10)
     };
 
     socket.emit("save_channel_changes", channel_updates);

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -165,6 +165,15 @@
               </div>
               <div class="form-group my-3">
                 <div class="row">
+                  <div class="col-8">
+                    <label for="keep-days">Minimum Duration (Minutes):</label>
+                    <input type="number" class="form-control border-secondary-subtle" min="0"
+                      id="minimum-duration-minutes" placeholder="Use -1 for Indefinite" value="">
+                  </div>
+                </div>
+              </div>
+              <div class="form-group my-3">
+                <div class="row">
                   <div class="col-4">
                     <label for="search-limit">Search Limit:</label>
                     <input type="number" class="form-control border-secondary-subtle" id="search-limit" value="">


### PR DESCRIPTION
This pull request introduces a new feature that allows setting a *minimum video duration per channel*, replacing the previously hardcoded value of 180 seconds.

### What's new
- A new parameter (in **minutes**) can now be configured for each channel to define the minimum video length required for download.
- By default, this parameter is set to **3 minutes**, maintaining compatibility with the previous hardcoded behavior.
- This is especially useful in cases such as podcast channels where shorter clips or reused segments from longer videos are published. With this parameter, users can ensure only full-length content is downloaded.
- It addresses use cases where filtering based on video titles is not feasible or reliable.

Let me know if any adjustments are needed. Thanks for reviewing!